### PR TITLE
Keep rolling Node.js versions with latest/LTS releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 sudo: false
 node_js:
-  - 4.0
-  - 6.0
+  - node
+  - lts/*
 branches:
   only:
     - master


### PR DESCRIPTION
Currently the tests are failing for the oldest version of Node.js the
test suite runs on.  This is version 4.0.0, which was a new version when
it was added to the Travis CI config in 2015, but it is now so old that
it is no longer supported.

Instead of dropping version 4 and adding new versions 12 (LTS) and 13
(latest), this commit uses Travis CI's built-in references:

- node (the latest version)
- lts/* (the currently supported LTS releases)

For details on current LTS support status of different versions, see:
https://nodejs.org/en/about/releases/